### PR TITLE
force headers to be str in flask response for login

### DIFF
--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -278,7 +278,7 @@ def login():
         return flask.Response(
             'Could not verify your access level for that URL.\n {}'.format(error),
             401,
-            {'WWW-Authenticate': 'Basic realm="Login Required"'})
+            {str('WWW-Authenticate'): str('Basic realm="Login Required"')})
     return flask.redirect(next or flask.url_for("user"))
 
 


### PR DESCRIPTION
Without explicity forcing the response headers to be str types, I get 500 a error (logs show aTypeError: expected byte string object for header name, value of type unicode found)  when attempting to use the login view/page with apache/mod_wsgi.  Each time you declare a string in the login view it becomes a unicode string, I'm guessing this is a werkzeug/flask thing, but I must admit, I don't really know why this happens.
