### PR TITLE
Pin Apscheduler to 2.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='ckanserviceprovider',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-            'APScheduler',
+            'APScheduler==2.1.2',
             'Flask',
             'SQLAlchemy',
             'requests',


### PR DESCRIPTION
API changed drastically in a backwards incompatible manner.
