### PR TITLE
Add HttpError, a subclass of JobError

### DIFF
--- a/ckanserviceprovider/util.py
+++ b/ckanserviceprovider/util.py
@@ -12,6 +12,16 @@ class JobError(Exception):
     pass
 
 
+class HttpError(JobError):
+    '''A Job Error raised by jobs that have are caused by http errors'''
+    def __init__(self, message, http_code=None, request_url=None,
+                 response=None):
+        super(JobError, self).__init__(message)
+        self.http_code=http_code
+        self.request_url=request_url
+        self.response=response
+
+
 class StoringHandler(logging.Handler):
     '''A handler that stores the logging records
     in the database.'''

--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -159,7 +159,13 @@ def job_listener(event):
             'Job delayed too long, service full')
     elif event.exception:
         update_dict['status'] = 'error'
-        if isinstance(event.exception, util.JobError):
+        if isinstance(event.exception, util.HttpError):
+            update_dict['error'] = json.dumps({
+                'code': event.exception.http_code,
+                'message': event.exception.message,
+                'response': event.exception.response,
+            })
+        elif isinstance(event.exception, util.JobError):
             update_dict['error'] = json.dumps(event.exception.message)
         else:
             update_dict['error'] = \


### PR DESCRIPTION
Allows greater control of the error message, instead of cramming the
entire message into the JobError.message. HttpError also stores the http
error code, url and original raw response
