### PR TITLE
Pin the version of flask-login and change is_authenticated() call

### DIFF
--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -692,7 +692,7 @@ def is_authorized(job=None):
     if provided. If no job is provided, the user has to be admin
     to be authorized.
     '''
-    if flogin.current_user.is_authenticated():
+    if flogin.current_user.is_authenticated:
         return True
     if job:
         job_key = flask.request.headers.get('Authorization')

--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -278,7 +278,7 @@ def login():
         username = auth.username
         password = auth.password
 
-    if not flogin.current_user.is_active():
+    if not flogin.current_user.is_active:
         error = 'You have to login with proper credentials'
         if username and password:
             if check_auth(username, password):
@@ -320,7 +320,7 @@ def user():
         'id': user.get_id(),
         'name': user.name,
         'is_active': user.is_active(),
-        'is_anonymous': user.is_anonymous()
+        'is_anonymous': user.is_anonymous
     })
 
 
@@ -731,6 +731,7 @@ def send_result(job_id, api_key=None):
         headers[header] = key
 
     try:
+        print result_url
         result = requests.post(
             result_url,
             data=json.dumps(job_dict, cls=DatetimeJsonEncoder),

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['APScheduler==2.1.2', 'Flask==0.9', 'SQLAlchemy==0.7.8', 'requests==2.5.0', 'flask-admin', 'flask-login'],
+    install_requires=['APScheduler==2.1.2', 'Flask==0.9', 'SQLAlchemy==0.7.8', 'requests==2.5.0', 'flask-admin', 'flask-login==0.3.0'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -726,6 +726,7 @@ class TestWeb(object):
             data=json.dumps({"job_type": "echo",
                              "api_key": 42}),
             content_type='application/json')
+
         assert response.status_code == 200, response.status
         job_status_data = json.loads(response.data)
         job_key = job_status_data['job_key']


### PR DESCRIPTION
Flask-login is unpinned in setup.py, and whilst it was on 0.2.11 it was fine. It's now been upgrade to 0.3.0 and a method (current_user.is_authenticated()) is now a property.

This PR pins flask-login to 0.3.0 and change is_authenticated() to is_authenticated.

Tests are broken, but they're broken on master too. Have explicitly tested the auth tests in TestWeb though and it passes.