### PR TITLE
Align flask version with CKAN, to avoid incompatibilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Suggested versions
+APScheduler==2.1.2
+requests==2.11.1
+Flask==0.11.1
+Flask-Admin==1.5.0
+Flask-Login==0.3.0

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['APScheduler==2.1.2', 'Flask==0.9', 'SQLAlchemy', 'requests==2.5.0', 'flask-admin', 'flask-login==0.3.0'],
+    install_requires=['APScheduler==2.1.2', 'Flask==0.11.1', 'SQLAlchemy', 'requests==2.11.1', 'flask-admin', 'flask-login==0.3.0'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,13 @@ setup(
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    install_requires=['APScheduler==2.1.2', 'Flask==0.11.1', 'SQLAlchemy', 'requests==2.11.1', 'flask-admin', 'flask-login==0.3.0'],
+    install_requires=[
+        'APScheduler>=2.1.2,<3.0.0',
+        'Flask',
+        'SQLAlchemy',
+        'requests',
+        'flask-admin',
+        'flask-login'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
Fixes: https://github.com/ckan/datapusher/issues/124

setup.py is no longer picky about versions - CKAN now specifies Flask and requests versions so that should not be overwritten when you install datapusher (during with you install ckan-service-provider, which might be done in the ckan deb package automatically).