### PR TITLE
Improved logging when a job error occurs

### DIFF
--- a/ckanserviceprovider/util.py
+++ b/ckanserviceprovider/util.py
@@ -29,6 +29,10 @@ class JobError(Exception):
         """
         return {"message": self.message}
 
+    def __str__(self):
+        return u'{}'.format(self.message) \
+            .encode('ascii', 'replace')
+
 
 class StoringHandler(logging.Handler):
     '''A handler that stores the logging records


### PR DESCRIPTION
This improves logging:

Before:
```
    raise util.JobError('Could not run dos2unix: {}'.format(e))
JobError
```

With this PR:
```
    raise util.JobError('Could not run dos2unix: {}'.format(e))
JobError: Could not run dos2unix: [Errno 2] No such file or directory
```

And I've not seen one yet, but I think there might be "JobError" displayed on occasion in the datapusher logs displayed to admins in the web interface, and this will help display the error message. The HTTPErrors (which derive from JobError) were given this treatment recently: https://github.com/ckan/datapusher/pull/121