### PR TITLE
Since pip 7, --use-mirrors has been deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - "2.7"
 install:
-  - pip install -r requirements-dev.txt --use-mirrors
-  - pip install coveralls --use-mirrors
+  - pip install -r requirements-dev.txt
+  - pip install coveralls
   - pip install .
 script: nosetests --with-coverage --cover-package=ckanserviceprovider
 after_success:


### PR DESCRIPTION
Looks like travis is now using a more recent version that no longer recognizes the option.