### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![Build Status](https://travis-ci.org/ckan/ckan-service-provider.png?branch=master)](https://travis-ci.org/ckan/ckan-service-provider)
 [![Coverage Status](https://coveralls.io/repos/ckan/ckan-service-provider/badge.png?branch=master)](https://coveralls.io/r/ckan/ckan-service-provider?branch=master)
-[![Latest Version](https://pypip.in/version/ckanserviceprovider/badge.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
-[![Downloads](https://pypip.in/download/ckanserviceprovider/badge.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
-[![Supported Python versions](https://pypip.in/py_versions/ckanserviceprovider/badge.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
-[![Development Status](https://pypip.in/status/ckanserviceprovider/badge.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
-[![License](https://pypip.in/license/ckanserviceprovider/badge.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
+[![Latest Version](https://img.shields.io/pypi/v/ckanserviceprovider.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
+[![Downloads](https://img.shields.io/pypi/dm/ckanserviceprovider.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/ckanserviceprovider.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
+[![Development Status](https://img.shields.io/pypi/status/ckanserviceprovider.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
+[![License](https://img.shields.io/pypi/l/ckanserviceprovider.svg)](https://pypi.python.org/pypi/ckanserviceprovider/)
 
 [DataPusher]: https://github.com/okfn/datapusher
 [PyPI]: https://pypi.python.org/pypi/ckanserviceprovider


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20ckanserviceprovider))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `ckanserviceprovider`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.