### PR TITLE
[#40] Constrain requirements according to what breaks. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,11 @@ setup(
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
     install_requires=[
         'APScheduler>=2.1.2,<3.0.0',
-        'Flask>=0.11.1,<1.0.0',
-        'SQLAlchemy>=1.2.7,<1.3.0',
-        'requests>=2.11.1,<2.12.0',
-        'flask-admin>=1.5.0,<1.6.0',
-        'flask-login>=0.3.0,<0.4.0'],
+        'Flask<1.0.0',
+        'SQLAlchemy',
+        'requests',
+        'flask-admin',
+        'flask-login'],
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
Fixes #40 

(Pinning is done in requirements.txt if you have trouble reproducing a working environment)

* Undoes the problems of https://github.com/ckan/ckan-service-provider/pull/39
* But I believe fixes https://github.com/ckan/ckan-service-provider/issues/38