### PR TITLE
fix log warning 'Importing flask.ext.login is deprecated'

### DIFF
--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -10,7 +10,7 @@ import logging
 import logging.handlers
 
 import flask
-import flask.ext.login as flogin
+import flask_login as flogin
 #from flask.ext.admin import Admin
 import werkzeug
 import apscheduler.scheduler as apscheduler


### PR DESCRIPTION
When using ckan-service-provider with datapusher, log warnings of type
`ExtDeprecationWarning: Importing flask.ext.login is deprecated, use flask_login instead`
are generated. As per suggestion, the flask_login replacement was made which fixes it.