### PR TITLE
Update import of flask_login plugin

### DIFF
--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -10,7 +10,7 @@ import logging
 import logging.handlers
 
 import flask
-import flask.ext.login as flogin
+import flask_login as flogin
 #from flask.ext.admin import Admin
 import werkzeug
 import apscheduler.scheduler as apscheduler


### PR DESCRIPTION
CKAN requires flask==0.12.4 (https://github.com/ckan/ckan/blob/154627dad768f3cc81ebfb7aee5e015fdc8adae5/requirements.txt#L15), which is now imported using `import flask_login` not `flask.ext.login`

This causes a 500 error in the datapusher when loading a csv file/spreadsheet, as reported:
* https://github.com/ckan/datapusher/issues/165
* https://github.com/ckan/datapusher/issues/167

This modification resolves the 500 error (at least on the instance I am running).
