### PR TITLE
Avoid warning about old-style flask imports

### DIFF
--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -10,7 +10,7 @@ import logging
 import logging.handlers
 
 import flask
-import flask.ext.login as flogin
+import flask_login as flogin
 #from flask.ext.admin import Admin
 import werkzeug
 import apscheduler.scheduler as apscheduler


### PR DESCRIPTION
Changes to latest flask import style, to avoid getting this warning:
```
/vagrant/src/ckan-service-provider/ckanserviceprovider/web.py:13: ExtDeprecationWarning: Importing flask.ext.login is deprecated, use flask_login instead.
```