### PR TITLE
accept limit for logs in query string

### DIFF
--- a/ckanserviceprovider/db.py
+++ b/ckanserviceprovider/db.py
@@ -95,7 +95,7 @@ def drop_all():
         _METADATA.drop_all(ENGINE)
 
 
-def get_job(job_id):
+def get_job(job_id, limit_logs=None):
     """Return the job with the given job_id as a dict.
 
     The dict also includes any metadata or logs associated with the job.
@@ -174,7 +174,7 @@ def get_job(job_id):
             result_dict[field] = unicode(value)
 
     result_dict['metadata'] = _get_metadata(job_id)
-    result_dict['logs'] = _get_logs(job_id)
+    result_dict['logs'] = _get_logs(job_id, limit=limit_logs)
 
     return result_dict
 
@@ -514,14 +514,25 @@ def _get_metadata(job_id):
     return metadata
 
 
-def _get_logs(job_id):
+def _get_logs(job_id, limit=None):
     """Return any logs for the given job_id from the logs table."""
     # Avoid SQLAlchemy "Unicode type received non-unicode bind param value"
     # warnings.
     job_id = unicode(job_id)
+    try:
+        int(limit)
+        limit_is_valid = True
+    except (ValueError, TypeError):
+        # None or "one" (or similar)
+        limit_is_valid = False
 
-    results = ENGINE.execute(
-        LOGS_TABLE.select().where(LOGS_TABLE.c.job_id == job_id)).fetchall()
+    if not limit_is_valid:
+        results = ENGINE.execute(
+            LOGS_TABLE.select().where(LOGS_TABLE.c.job_id == job_id)).fetchall()
+    else:
+        results = ENGINE.execute(
+            LOGS_TABLE.select().where(LOGS_TABLE.c.job_id == job_id).\
+                order_by(LOGS_TABLE.c.timestamp.desc()).limit(limit)).fetchall()
 
     results = [dict(result) for result in results]
 
@@ -529,3 +540,35 @@ def _get_logs(job_id):
         result.pop("job_id")
 
     return results
+
+
+def add_logs(job_id, message=None, level=None,
+                    module=None, funcName=None, lineno=None):
+    """for tests only
+
+    """
+    if job_id:
+        job_id = unicode(job_id)
+    if message:
+        message = unicode(message)
+    if level:
+        level = unicode(level)
+    if module:
+        module = unicode(module)
+    if funcName:
+        funcName = unicode(funcName)
+    if lineno:
+        lineno = unicode(lineno)
+    conn = ENGINE.connect()
+    trans = conn.begin()
+
+    conn.execute(LOGS_TABLE.insert().values(
+        job_id=job_id,
+        timestamp=datetime.datetime.now(),
+        message=message,
+        level=level,
+        module=module,
+        funcName=funcName,
+        lineno=lineno))
+    trans.commit()
+    conn.close()

--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -437,7 +437,8 @@ def job_status(job_id, show_job_key=False, ignore_auth=False):
     :statuscode 404: job id not found
     :statuscode 409: an error occurred
     '''
-    job_dict = db.get_job(job_id)
+    limit_logs = flask.request.args.get('limit_logs')
+    job_dict = db.get_job(job_id, limit_logs=limit_logs)
     if not job_dict:
         return json.dumps({'error': 'job_id not found'}), 404, headers
     if not ignore_auth and not is_authorized(job_dict):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -181,6 +181,29 @@ class TestWeb(object):
     def teardown(self):
         reset_db()
 
+    def test_get_job_id_with_limit(self):
+        '''Limiting logs works fine'''
+        client = test_client()
+        client.post(
+            '/job/12345',
+            data=json.dumps({"job_type": "example",
+                             "api_key": 42,
+                             "data": {"time": 0.1}}),
+            content_type='application/json')
+        db.add_logs(job_id='12345', message='message1')
+        db.add_logs(job_id='12345', message='message2')
+        db.add_logs(job_id='12345', message='message3')
+
+        # Make sure it works without limit
+        response = client.get('/job/12345', headers={'Authorization': 'please_replace_me'})
+        return_data = json.loads(response.data)
+        assert len(return_data['logs']) == 3
+
+        # Now test with limit
+        response = client.get('/job/12345?limit_logs=2', headers={'Authorization': 'please_replace_me'})
+        return_data = json.loads(response.data)
+        assert len(return_data['logs']) == 2
+
     def test_status(self):
         '''/status should return JSON with the app version, job types, etc.'''
         client = test_client()


### PR DESCRIPTION
We have a case when datapusher is uploading quite big files in datastore. 

While the data gets in the DataStore, all activities (Log for every single chunk) is also saved in logs table.  As the data gets the bigger, that table also gets bigger and bigger (thousands of rows). Later when that info is requested by CKAN to just display the datastore page `ckan-service-provider` responds with **all** that data in a single response. This makes response time extremely slow and CKAN closes connection due to timeout. 

This PR allows passing `limit_logs` parameter to `job/{job_ud}`  as a query string and returns a limited number of logs. 