### PR TITLE
Update ProxyFix import to work with current Flask (werkzeug) version

### DIFF
--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -18,7 +18,7 @@ import apscheduler.jobstores.sqlalchemy_store as sqlalchemy_store
 import sqlalchemy.sql as sql
 import sqlalchemy as sa
 import requests
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 import db
 import util


### PR DESCRIPTION
Currently, even with the pinned version of Flask, werkzeug==1.0.0 is installed as dependency. This causes new installations to fail with
```
Traceback (most recent call last):
  File "/etc/ckan-datapusher/datapusher.wsgi", line 4, in <module>
    import ckanserviceprovider.web as web
  File "/usr/lib/python2.7/site-packages/ckanserviceprovider/web.py", line 21, in <module>
    from werkzeug.contrib.fixers import ProxyFix
ImportError: No module named contrib.fixers
```
as the ProxyFix class has been moved in 0.15.0 (see https://werkzeug.palletsprojects.com/en/0.15.x/contrib/fixers/)

This PR updates the ProxyFix import so it works correctly again.