### PR TITLE
fix JobError.__str__() for python 2/3 compat

### DIFF
--- a/ckanserviceprovider/util.py
+++ b/ckanserviceprovider/util.py
@@ -3,10 +3,12 @@
 
 import logging
 import datetime
+from future.utils import python_2_unicode_compatible
 
 from . import db
 
 
+@python_2_unicode_compatible
 class JobError(Exception):
     """The exception type that jobs raise to signal failure."""
 
@@ -30,8 +32,7 @@ class JobError(Exception):
         return {"message": self.message}
 
     def __str__(self):
-        return '{}'.format(self.message) \
-            .encode('ascii', 'replace')
+        return self.message
 
 
 class StoringHandler(logging.Handler):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ APScheduler==2.1.2
 requests==2.23.0
 Flask==1.1.1
 Flask-Login==0.5.0
+future==0.18.2

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = [
     'SQLAlchemy>=1.3.15,<1.4.0',
     'requests>=2.23.0',
     'flask-login>=0.5.0,<0.6.0',
+    'future',
 ]
 
 if sys.version_info[0] < 3:

--- a/tests/test_joberror.py
+++ b/tests/test_joberror.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from ckanserviceprovider.util import JobError
+
+def test_joberror():
+    err = JobError(u'oh no ❌')
+    assert err.message == u'oh no ❌'
+    assert str(err) == 'oh no ❌'


### PR DESCRIPTION
Calling `str()` on a `JobError` in python 3 throws `TypeError: __str__ returned non-string (type bytes)`
This PR gives `str()` a valid return value in both python2 and python3