### PR TITLE
log to stderr by default

### DIFF
--- a/ckanserviceprovider/default_settings.py
+++ b/ckanserviceprovider/default_settings.py
@@ -6,6 +6,8 @@ SECRET_KEY = 'please_replace_me'
 USERNAME = 'admin'
 PASSWORD = 'pass'
 
+STDERR = True
+
 # database
 
 SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite://')

--- a/ckanserviceprovider/default_settings.py
+++ b/ckanserviceprovider/default_settings.py
@@ -6,8 +6,6 @@ SECRET_KEY = 'please_replace_me'
 USERNAME = 'admin'
 PASSWORD = 'pass'
 
-STDERR = True
-
 # database
 
 SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite://')
@@ -21,6 +19,7 @@ PORT = 8000
 # logging
 
 LOG_FILE = '/tmp/ckan_service.log'
+STDERR = True
 
 # project configuration
 NAME = 'service'

--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -99,10 +99,10 @@ def _configure_logger_for_production(logger):
     if 'STDERR' in app.config and app.config['STDERR']:
         logger.addHandler(stderr_handler)
 
-    file_handler = logging.handlers.RotatingFileHandler(
-        app.config.get('LOG_FILE'), maxBytes=67108864, backupCount=5)
-    file_handler.setLevel(logging.INFO)
-    if 'LOG_FILE' in app.config:
+    if 'LOG_FILE' in app.config and app.config['LOG_FILE']:
+        file_handler = logging.handlers.RotatingFileHandler(
+            app.config.get('LOG_FILE'), maxBytes=67108864, backupCount=5)
+        file_handler.setLevel(logging.INFO)
         logger.addHandler(file_handler)
 
     mail_handler = logging.handlers.SMTPHandler(

--- a/ckanserviceprovider/web.py
+++ b/ckanserviceprovider/web.py
@@ -96,7 +96,7 @@ def _configure_logger_for_production(logger):
     """
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setLevel(logging.INFO)
-    if 'STDERR' in app.config:
+    if 'STDERR' in app.config and app.config['STDERR']:
         logger.addHandler(stderr_handler)
 
     file_handler = logging.handlers.RotatingFileHandler(


### PR DESCRIPTION
During the administration of an installation of CKAN I found that I was expecting it to log to stderr by default.

Advantages:

- errors are easily seen during development
- setups that use systemd/journald can see errors where they are expected

As part of this merge request it is possible to disable stderr by setting `STDERR = False`. It was not possible before because the code just expected the variable to be set but didn't check its value.